### PR TITLE
Add Limited-Last Life addon and generic limited-life-like handling with extra color ranges and team backup/restore

### DIFF
--- a/addons/limitedlastlife-addon/README.md
+++ b/addons/limitedlastlife-addon/README.md
@@ -1,0 +1,35 @@
+# Limited-Last Life Addon
+
+This folder is a standalone Fabric addon mod project. Build it into its own jar and place it next to the main `lifeseries` mod jar.
+
+## What it adds
+- `limitedlastlife` season implementation.
+- Limited-Last Life team/color behavior:
+  - `1 = Dark Red`
+  - `2 = Red`
+  - `3 = Yellow`
+  - `4 = Green`
+  - `5 = Dark Green`
+  - `6 = Blue`
+- Team backup/restore when switching in/out of the season.
+- Default randomized time lives and extra color thresholds (`0-1h dark red`, `32h + 1s blue`).
+
+## Why this works
+LifeSeries core resolves `limitedlastlife` by reflecting the class
+`net.mat0u5.lifeseries.seasons.season.limitedlastlife.LimitedLastLife`.
+When this addon is installed, that class exists and the season is enabled.
+
+## Build
+From repository root:
+
+```bash
+bash ./gradlew -p addons/limitedlastlife-addon build -Plifeseries_jar=/absolute/path/to/lifeseries.jar
+```
+
+- `lifeseries_jar` must point to the main mod jar for compile-time symbols.
+- Output jar: `addons/limitedlastlife-addon/build/libs/`
+
+## Install
+Put both jars in your server/client `mods/` folder:
+1. `lifeseries` main mod jar
+2. `lifeseries-limitedlastlife-addon` jar built from this folder

--- a/addons/limitedlastlife-addon/build.gradle
+++ b/addons/limitedlastlife-addon/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'fabric-loom' version '1.15-SNAPSHOT'
+    id 'maven-publish'
+}
+
+group = 'net.mat0u5.lifeseries.addons'
+version = project.addon_version
+base {
+    archivesName = project.archives_base_name
+}
+
+repositories {
+    maven { url = 'https://maven.fabricmc.net/' }
+    mavenCentral()
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:${project.minecraft_version}"
+    mappings loom.officialMojangMappings()
+    modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+
+    // Required only for compilation. Override with -Plifeseries_jar=/path/to/lifeseries.jar
+    modCompileOnly files(project.lifeseries_jar)
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+}
+
+java {
+    withSourcesJar()
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+processResources {
+    inputs.property 'version', project.version
+    filesMatching('fabric.mod.json') {
+        expand(version: project.version)
+    }
+}

--- a/addons/limitedlastlife-addon/gradle.properties
+++ b/addons/limitedlastlife-addon/gradle.properties
@@ -1,0 +1,11 @@
+org.gradle.jvmargs=-Xmx2G
+
+minecraft_version=1.21.11
+loader_version=0.18.4
+
+addon_version=1.0.0
+archives_base_name=lifeseries-limitedlastlife-addon
+
+# Path to the compiled LifeSeriesPlus jar used as a compile-time dependency.
+# Override with: -Plifeseries_jar=/absolute/path/to/lifeseries.jar
+lifeseries_jar=../../build/libs/lifeseries.jar

--- a/addons/limitedlastlife-addon/settings.gradle
+++ b/addons/limitedlastlife-addon/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        maven { url = 'https://maven.fabricmc.net/' }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'limitedlastlife-addon'

--- a/addons/limitedlastlife-addon/src/main/java/net/mat0u5/lifeseries/addon/limitedlastlife/LimitedLastLifeAddon.java
+++ b/addons/limitedlastlife-addon/src/main/java/net/mat0u5/lifeseries/addon/limitedlastlife/LimitedLastLifeAddon.java
@@ -1,0 +1,10 @@
+package net.mat0u5.lifeseries.addon.limitedlastlife;
+
+import net.fabricmc.api.ModInitializer;
+
+public class LimitedLastLifeAddon implements ModInitializer {
+    @Override
+    public void onInitialize() {
+        // No-op. LifeSeries core loads the Limited-Last Life season class via reflection.
+    }
+}

--- a/addons/limitedlastlife-addon/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlastlife/LimitedLastLife.java
+++ b/addons/limitedlastlife-addon/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlastlife/LimitedLastLife.java
@@ -1,0 +1,46 @@
+package net.mat0u5.lifeseries.seasons.season.limitedlastlife;
+
+import net.mat0u5.lifeseries.config.ConfigManager;
+import net.mat0u5.lifeseries.seasons.other.LivesManager;
+import net.mat0u5.lifeseries.seasons.season.Seasons;
+import net.mat0u5.lifeseries.seasons.season.limitedlife.LimitedLife;
+import net.mat0u5.lifeseries.seasons.season.limitedlife.LimitedLifeConfig;
+import net.mat0u5.lifeseries.utils.other.Time;
+
+public class LimitedLastLife extends LimitedLife {
+
+    @Override
+    public Seasons getSeason() {
+        return Seasons.LIMITED_LAST_LIFE;
+    }
+
+    @Override
+    public ConfigManager createConfig() {
+        return new Config();
+    }
+
+    @Override
+    public LivesManager createLivesManager() {
+        return new LimitedLastLifeLivesManager();
+    }
+
+    @Override
+    public void switchOutOfSeason(Seasons changedTo) {
+        LimitedLastLifeLivesManager.restoreTeamsFromBackup();
+    }
+
+    public static class Config extends LimitedLifeConfig {
+        public Config() {
+            super("limitedlastlife.properties");
+        }
+
+        @Override
+        protected void applyLimitedLifeDefaults() {
+            super.applyLimitedLifeDefaults();
+            LIVES_RANDOMIZE.defaultValue = true;
+            LIVES_RANDOMIZE_MIN.defaultValue = Time.hours(12).getSeconds();
+            LIVES_RANDOMIZE_MAX.defaultValue = Time.hours(36).getSeconds();
+            EXTRA_LIFE_COLORS.defaultValue = "0-3600:dark_red;115201-2147483647:blue";
+        }
+    }
+}

--- a/addons/limitedlastlife-addon/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlastlife/LimitedLastLifeLivesManager.java
+++ b/addons/limitedlastlife-addon/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlastlife/LimitedLastLifeLivesManager.java
@@ -1,0 +1,129 @@
+package net.mat0u5.lifeseries.seasons.season.limitedlastlife;
+
+import net.mat0u5.lifeseries.Main;
+import net.mat0u5.lifeseries.seasons.season.limitedlife.LimitedLifeLivesManager;
+import net.mat0u5.lifeseries.utils.other.Time;
+import net.mat0u5.lifeseries.utils.player.TeamUtils;
+import net.minecraft.ChatFormatting;
+import net.minecraft.world.scores.PlayerTeam;
+
+import java.util.Locale;
+
+public class LimitedLastLifeLivesManager extends LimitedLifeLivesManager {
+    public static int DARK_RED_TIME = Time.hours(1).getSeconds();
+    public static int BLUE_TIME = Time.hours(32).getSeconds() + 1;
+
+    @Override
+    public ChatFormatting getColorForLives(Integer lives) {
+        lives = getEquivalentLives(lives);
+        if (lives == null) return ChatFormatting.GRAY;
+        if (lives == 1) return ChatFormatting.DARK_RED;
+        if (lives == 2) return ChatFormatting.RED;
+        if (lives == 3) return ChatFormatting.YELLOW;
+        if (lives == 4) return ChatFormatting.GREEN;
+        if (lives == 5) return ChatFormatting.DARK_GREEN;
+        if (lives >= 6) return ChatFormatting.BLUE;
+        return ChatFormatting.DARK_GRAY;
+    }
+
+    @Override
+    public Integer getEquivalentLives(Integer limitedLifeLives) {
+        if (limitedLifeLives == null) return null;
+        if (limitedLifeLives <= 0) return 0;
+        if (limitedLifeLives <= DARK_RED_TIME) return 1;
+        if (limitedLifeLives <= RED_TIME) return 2;
+        if (limitedLifeLives <= YELLOW_TIME) return 3;
+        if (limitedLifeLives <= DEFAULT_TIME) return 4;
+        if (limitedLifeLives < BLUE_TIME) return 5;
+        return 6;
+    }
+
+    @Override
+    public String getTeamForLives(Integer lives) {
+        lives = getEquivalentLives(lives);
+        if (lives == null) return "lives_null";
+        if (lives <= 0) return "lives_0";
+        if (lives >= 6) return "lives_6";
+        return "lives_" + lives;
+    }
+
+    @Override
+    public void createTeams() {
+        TeamUtils.createTeam("lives_null", "Unassigned", ChatFormatting.GRAY);
+        TeamUtils.createTeam("lives_0", "Dead", ChatFormatting.DARK_GRAY);
+
+        boolean alreadyOverridden = Main.seasonConfig.getOrCreateBoolean("limitedlastlife_teams_overridden", false);
+        if (!alreadyOverridden) {
+            backupTeam("lives_1");
+            backupTeam("lives_2");
+            backupTeam("lives_3");
+            backupTeam("lives_4");
+            backupTeam("lives_5");
+            backupTeam("lives_6");
+            Main.seasonConfig.setProperty("limitedlastlife_teams_overridden", "true");
+        }
+
+        replaceTeam("lives_1", "Dark Red", ChatFormatting.DARK_RED);
+        replaceTeam("lives_2", "Red", ChatFormatting.RED);
+        replaceTeam("lives_3", "Yellow", ChatFormatting.YELLOW);
+        replaceTeam("lives_4", "Green", ChatFormatting.GREEN);
+        replaceTeam("lives_5", "Dark Green", ChatFormatting.DARK_GREEN);
+        replaceTeam("lives_6", "Blue", ChatFormatting.BLUE);
+    }
+
+    @Override
+    public int defaultTeamCanKill(String teamName) {
+        if (teamName.equals("lives_1")) return 1;
+        if (teamName.equals("lives_2")) return YELLOW_TIME;
+        return -1;
+    }
+
+    @Override
+    public int defaultTeamGainLife(String teamName) {
+        if (teamName.equals("lives_1")) return 1;
+        if (teamName.equals("lives_2")) return YELLOW_TIME;
+        return -1;
+    }
+
+    public static void restoreTeamsFromBackup() {
+        restoreTeam("lives_1", "Red", ChatFormatting.RED);
+        restoreTeam("lives_2", "Yellow", ChatFormatting.YELLOW);
+        restoreTeam("lives_3", "Green", ChatFormatting.GREEN);
+        restoreTeam("lives_4", "Dark Green", ChatFormatting.DARK_GREEN);
+        restoreTeam("lives_5", "Blue", ChatFormatting.BLUE);
+        restoreTeam("lives_6", "Dark Blue", ChatFormatting.DARK_BLUE);
+        Main.seasonConfig.setProperty("limitedlastlife_teams_overridden", "false");
+    }
+
+    private static void replaceTeam(String teamName, String displayName, ChatFormatting color) {
+        TeamUtils.deleteTeam(teamName);
+        TeamUtils.createTeam(teamName, displayName, color);
+    }
+
+    private static void backupTeam(String teamName) {
+        PlayerTeam team = TeamUtils.getTeam(teamName);
+        String keyPrefix = "limitedlastlife_backup_" + teamName;
+        boolean exists = team != null;
+        Main.seasonConfig.setProperty(keyPrefix + "_exists", String.valueOf(exists));
+        if (exists) {
+            Main.seasonConfig.setProperty(keyPrefix + "_display", team.getDisplayName().getString());
+            ChatFormatting color = team.getColor();
+            Main.seasonConfig.setProperty(keyPrefix + "_color", color == null ? "white" : color.getName().toLowerCase(Locale.ROOT));
+        }
+    }
+
+    private static void restoreTeam(String teamName, String fallbackDisplayName, ChatFormatting fallbackColor) {
+        String keyPrefix = "limitedlastlife_backup_" + teamName;
+        boolean existed = Main.seasonConfig.getOrCreateBoolean(keyPrefix + "_exists", true);
+
+        TeamUtils.deleteTeam(teamName);
+        if (!existed) return;
+
+        String display = Main.seasonConfig.getOrCreateProperty(keyPrefix + "_display", fallbackDisplayName);
+        String colorName = Main.seasonConfig.getOrCreateProperty(keyPrefix + "_color", fallbackColor.getName());
+        ChatFormatting color = ChatFormatting.getByName(colorName);
+        if (color == null) color = fallbackColor;
+
+        TeamUtils.createTeam(teamName, display, color);
+    }
+}

--- a/addons/limitedlastlife-addon/src/main/resources/fabric.mod.json
+++ b/addons/limitedlastlife-addon/src/main/resources/fabric.mod.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "id": "lifeseries_limitedlastlife_addon",
+  "version": "${version}",
+  "name": "LifeSeries Limited-Last Life Addon",
+  "description": "Adds the Limited-Last Life series to LifeSeries when installed together.",
+  "authors": [
+    "LifeSeriesPlus"
+  ],
+  "license": "All-Rights-Reserved",
+  "environment": "*",
+  "entrypoints": {
+    "main": [
+      "net.mat0u5.lifeseries.addon.limitedlastlife.LimitedLastLifeAddon"
+    ]
+  },
+  "depends": {
+    "fabricloader": ">=0.15.0",
+    "minecraft": "*",
+    "lifeseries": "*"
+  }
+}

--- a/src/client/java/net/mat0u5/lifeseries/gui/config/entries/extra/TeamConfigEntry.java
+++ b/src/client/java/net/mat0u5/lifeseries/gui/config/entries/extra/TeamConfigEntry.java
@@ -183,7 +183,7 @@ public class TeamConfigEntry extends ModifiableListEntry {
     }
     public void renderLastEntryExtras(GuiGraphics context, int x, int y, int width, int height, int mouseX, int mouseY, boolean hovered, float tickDelta) {
         super.renderLastEntryExtras(context, x, y, width, height, mouseX, mouseY, hovered, tickDelta);
-        addEntryButton.active = MainClient.clientCurrentSeason != Seasons.LIMITED_LIFE;
+        addEntryButton.active = !MainClient.clientCurrentSeason.isLimitedLifeLike();
     }
     public void renderMiddleEntryExtras(GuiGraphics context, int x, int y, int width, int height, int mouseX, int mouseY, boolean hovered, float tickDelta) {
         super.renderMiddleEntryExtras(context, x, y, width, height, mouseX, mouseY, hovered, tickDelta);
@@ -265,7 +265,7 @@ public class TeamConfigEntry extends ModifiableListEntry {
 
     @Override
     public boolean isLast() {
-        if (MainClient.clientCurrentSeason == Seasons.LIMITED_LIFE) return false;
+        if (MainClient.clientCurrentSeason.isLimitedLifeLike()) return false;
         return super.isLast();
     }
 

--- a/src/client/java/net/mat0u5/lifeseries/gui/seasons/ChooseSeasonScreen.java
+++ b/src/client/java/net/mat0u5/lifeseries/gui/seasons/ChooseSeasonScreen.java
@@ -43,7 +43,7 @@ public class ChooseSeasonScreen extends DefaultScreen {
 
     public void addSeasonRegions() {
         seasonRegions.clear();
-        List<Seasons> seasons = Seasons.getSeasons();
+        List<Seasons> seasons = Seasons.getVisibleSeasonsInGui();
         seasons.removeAll(Seasons.getAprilFoolsSeasons());
 
         List<List<Seasons>> rows = splitIntoRows(seasons, ROWS);
@@ -191,4 +191,3 @@ public class ChooseSeasonScreen extends DefaultScreen {
         RenderUtils.texture(seasonRegion.season.getLogo(), rect.x, rect.y, textureSize, textureSize).scaled(scale, scale).render(context);
     }
 }
-

--- a/src/client/java/net/mat0u5/lifeseries/mixin/client/EntityRendererMixin.java
+++ b/src/client/java/net/mat0u5/lifeseries/mixin/client/EntityRendererMixin.java
@@ -112,7 +112,7 @@ public class EntityRendererMixin<T extends Entity, S extends EntityRenderState> 
             if (objective != null) {
                 ReadOnlyScoreInfo scoreInfo = scoreboard.getPlayerScoreInfo(player, objective);
                 if (scoreInfo != null && objective.getName().equalsIgnoreCase(LivesManager.SCOREBOARD_NAME)) {
-                    if (MainClient.clientCurrentSeason == Seasons.LIMITED_LIFE) {
+                    if (MainClient.clientCurrentSeason.isLimitedLifeLike()) {
                         return Component.literal(Time.seconds(scoreInfo.value()).formatLong()).setStyle(player.getDisplayName().getStyle());
                     }
                 }

--- a/src/client/java/net/mat0u5/lifeseries/mixin/client/PlayerEntityRendererMixin.java
+++ b/src/client/java/net/mat0u5/lifeseries/mixin/client/PlayerEntityRendererMixin.java
@@ -108,7 +108,7 @@ public abstract class PlayerEntityRendererMixin {
         if (objective != null) {
             Score score = scoreboard.getOrCreatePlayerScore(abstractClientPlayer.getScoreboardName(), objective);
             if (objective.getName().equalsIgnoreCase(LivesManager.SCOREBOARD_NAME)) {
-                if (MainClient.clientCurrentSeason == Seasons.LIMITED_LIFE) {
+                if (MainClient.clientCurrentSeason.isLimitedLifeLike()) {
                     Time timeLeft = Time.seconds(Math.max(0, score.getScore()));
                     return Component.literal(timeLeft.formatLong() + ";").setStyle(abstractClientPlayer.getDisplayName().getStyle());
                 }
@@ -136,7 +136,7 @@ public abstract class PlayerEntityRendererMixin {
         Objective objective = scoreboard.getDisplayObjective(DisplaySlot.BELOW_NAME);
         if (objective != null && readOnlyScoreInfo != null) {
             if (objective.getName().equalsIgnoreCase(LivesManager.SCOREBOARD_NAME)) {
-                if (MainClient.clientCurrentSeason == Seasons.LIMITED_LIFE) {
+                if (MainClient.clientCurrentSeason.isLimitedLifeLike()) {
                     Time timeLeft = Time.seconds(Math.max(0, readOnlyScoreInfo.value()));
                     return Component.literal(timeLeft.formatLong() + ";").setStyle(abstractClientPlayer.getDisplayName().getStyle());
                 }
@@ -175,7 +175,7 @@ public abstract class PlayerEntityRendererMixin {
             if (objective != null) {
                 ReadOnlyScoreInfo scoreInfo = scoreboard.getPlayerScoreInfo(player, objective);
                 if (scoreInfo != null && objective.getName().equalsIgnoreCase(LivesManager.SCOREBOARD_NAME)) {
-                    if (MainClient.clientCurrentSeason == Seasons.LIMITED_LIFE) {
+                    if (MainClient.clientCurrentSeason.isLimitedLifeLike()) {
                         return Component.literal(Time.seconds(scoreInfo.value()).formatLong()).setStyle(player.getDisplayName().getStyle());
                     }
                 }

--- a/src/client/java/net/mat0u5/lifeseries/mixin/client/PlayerTabOverlayMixin.java
+++ b/src/client/java/net/mat0u5/lifeseries/mixin/client/PlayerTabOverlayMixin.java
@@ -40,7 +40,7 @@ public class PlayerTabOverlayMixin {
             int score = objective.getScoreboard().getOrCreatePlayerScore(string, objective).getScore();
             if (objective.getName().equals(LivesManager.SCOREBOARD_NAME)) {
                 Component renderOverride = null;
-                if (MainClient.clientCurrentSeason != Seasons.LIMITED_LIFE) {
+                if (!MainClient.clientCurrentSeason.isLimitedLifeLike()) {
                     if (score >= MainClient.TAB_LIST_LIVES_CUTOFF && !MainClient.TAB_LIST_SHOW_EXACT_LIVES && !Main.DEBUG) {
                         renderOverride = Component.literal(MainClient.TAB_LIST_LIVES_CUTOFF+"+").withStyle(ChatFormatting.YELLOW);
                     }
@@ -67,7 +67,7 @@ public class PlayerTabOverlayMixin {
 
         if (objective != null && objective.getName().equals(LivesManager.SCOREBOARD_NAME)) {
             int score = readableScoreboardScore.value();
-            if (MainClient.clientCurrentSeason != Seasons.LIMITED_LIFE) {
+            if (!MainClient.clientCurrentSeason.isLimitedLifeLike()) {
                 if (score >= MainClient.TAB_LIST_LIVES_CUTOFF && !MainClient.TAB_LIST_SHOW_EXACT_LIVES && !Main.DEBUG) {
                     return Component.literal(MainClient.TAB_LIST_LIVES_CUTOFF+"+").setStyle(originalText.getStyle());
                 }

--- a/src/client/java/net/mat0u5/lifeseries/render/TextHud.java
+++ b/src/client/java/net/mat0u5/lifeseries/render/TextHud.java
@@ -129,7 +129,7 @@ public class TextHud {
 
     private static long limitedLifeTime = -1;
     public static int renderLimitedLifeTimer(Minecraft client, GuiGraphics context, int y) {
-        if (MainClient.clientCurrentSeason != Seasons.LIMITED_LIFE) return 0;
+        if (!MainClient.clientCurrentSeason.isLimitedLifeLike()) return 0;
         if (System.currentTimeMillis()-MainClient.limitedLifeTimeLastUpdated > 15000) return 0;
 
         MutableComponent timerText = Component.empty();
@@ -145,10 +145,8 @@ public class TextHud {
                     currentSeconds += secondsDifference;
                 }
             }
-            long remainingTime = currentSeconds * 1000;
-
-            if (remainingTime < 0) timerText = timerText.append(TextUtils.formatLoosely("{}0:00:00", MainClient.limitedLifeTimerColor));
-            else timerText = timerText.append(Component.nullToEmpty(MainClient.limitedLifeTimerColor+ Time.millis(remainingTime).formatLong()));
+            if (currentSeconds < 0) timerText = timerText.append(TextUtils.formatLoosely("{}0:00:00", MainClient.limitedLifeTimerColor));
+            else timerText = timerText.append(Component.nullToEmpty(MainClient.limitedLifeTimerColor + Time.seconds((int) currentSeconds).formatLong()));
         }
 
         return drawHudText(client, context, timerText, y);

--- a/src/main/java/net/mat0u5/lifeseries/command/GivelifeCommand.java
+++ b/src/main/java/net/mat0u5/lifeseries/command/GivelifeCommand.java
@@ -82,7 +82,7 @@ public class GivelifeCommand extends Command {
         }
 
         int giveAmount = 1;
-        if (currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason.getSeason().isLimitedLifeLike()) {
             giveAmount = -LimitedLife.NEW_DEATH_NORMAL.getSeconds();
         }
 

--- a/src/main/java/net/mat0u5/lifeseries/command/LivesCommand.java
+++ b/src/main/java/net/mat0u5/lifeseries/command/LivesCommand.java
@@ -45,7 +45,7 @@ public class LivesCommand extends Command {
     }
 
     public boolean isNormalLife() {
-        return currentSeason.getSeason() != Seasons.LIMITED_LIFE;
+        return !currentSeason.getSeason().isLimitedLifeLike();
     }
 
     @Override

--- a/src/main/java/net/mat0u5/lifeseries/config/ModifiableText.java
+++ b/src/main/java/net/mat0u5/lifeseries/config/ModifiableText.java
@@ -587,7 +587,7 @@ public enum ModifiableText {
     }
 
     public String getRegisterDefaultValue() {
-        if (currentSeason != null && currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason != null && currentSeason.getSeason().isLimitedLifeLike()) {
             String modified = null;
 
             if (this == GIVELIFE_RECEIVE_OTHER) modified = "{} received {} from {}";
@@ -628,7 +628,7 @@ public enum ModifiableText {
     }
 
     public List<String> getRegisterArgs() {
-        if (currentSeason != null && currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason != null && currentSeason.getSeason().isLimitedLifeLike()) {
 
             if (this == GIVELIFE_RECEIVE_OTHER) return List.of("Receiver", "time", "Giver");
             else if (this == GIVELIFE_RECEIVE_SELF) return List.of("time", "Player");
@@ -669,7 +669,15 @@ public enum ModifiableText {
             }
             */
 
-            if (modifiableText.requiredSeason != null && currentSeason != null && currentSeason.getSeason() != modifiableText.requiredSeason) continue;
+            if (modifiableText.requiredSeason != null && currentSeason != null) {
+                Seasons current = currentSeason.getSeason();
+                if (modifiableText.requiredSeason.isLimitedLifeLike()) {
+                    if (!current.isLimitedLifeLike()) continue;
+                }
+                else if (current != modifiableText.requiredSeason) {
+                    continue;
+                }
+            }
             ModifiableTextManager.register(modifiableText.name, defaultValue, modifiableText.getRegisterArgs());
         }
     }

--- a/src/main/java/net/mat0u5/lifeseries/seasons/boogeyman/BoogeymanManager.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/boogeyman/BoogeymanManager.java
@@ -607,7 +607,7 @@ public class BoogeymanManager {
         if (!BOOGEYMAN_ADVANCED_DEATHS) {
             delay = 140;
         }
-        if (currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason.getSeason().isLimitedLifeLike()) {
             delay = 140;
         }
 

--- a/src/main/java/net/mat0u5/lifeseries/seasons/boogeyman/advanceddeaths/AdvancedDeathsManager.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/boogeyman/advanceddeaths/AdvancedDeathsManager.java
@@ -53,7 +53,7 @@ public class AdvancedDeathsManager {
             return;
         }
         int amountOfDeaths = currentLives - lives;
-        if (currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason.getSeason().isLimitedLifeLike()) {
             amountOfDeaths = (int) Math.ceil(((double) amountOfDeaths) / Math.abs(LimitedLife.NEW_DEATH_NORMAL.getSeconds()));
         }
 

--- a/src/main/java/net/mat0u5/lifeseries/seasons/other/LivesManager.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/other/LivesManager.java
@@ -128,7 +128,7 @@ public class LivesManager {
                 return 3;
             }
         }
-        if (currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason.getSeason().isLimitedLifeLike()) {
             if (teamName.equals("lives_2")) {
                 return LimitedLifeLivesManager.YELLOW_TIME;
             }
@@ -145,7 +145,7 @@ public class LivesManager {
                 return 4;
             }
         }
-        if (currentSeason.getSeason() == Seasons.LIMITED_LIFE) {
+        if (currentSeason.getSeason().isLimitedLifeLike()) {
             if (teamName.equals("lives_1")) {
                 return 1;
             }

--- a/src/main/java/net/mat0u5/lifeseries/seasons/season/Season.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/season/Season.java
@@ -214,7 +214,7 @@ public abstract class Season {
         }
 
         Objective currentBelowNameObjective = ScoreboardUtils.getObjectiveInSlot(belowNameSlot);
-        if (getSeason() == Seasons.LIMITED_LIFE && LimitedLife.SHOW_TIME_BELOW_NAME) {
+        if (getSeason().isLimitedLifeLike() && LimitedLife.SHOW_TIME_BELOW_NAME) {
             ScoreboardUtils.setObjectiveInSlot(belowNameSlot, LivesManager.SCOREBOARD_NAME);
         }
         else if (SHOW_HEALTH_BELOW_NAME) {

--- a/src/main/java/net/mat0u5/lifeseries/seasons/season/Seasons.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/season/Seasons.java
@@ -29,6 +29,7 @@ public enum Seasons {
     LAST_LIFE("Last Life", "lastlife"),
     DOUBLE_LIFE("Double Life", "doublelife"),
     LIMITED_LIFE("Limited Life", "limitedlife"),
+    LIMITED_LAST_LIFE("Limited-Last Life", "limitedlastlife"),
     SECRET_LIFE("Secret Life", "secretlife"),
     WILD_LIFE("Wild Life", "wildlife"),
     PAST_LIFE("Past Life", "pastlife"),
@@ -58,6 +59,9 @@ public enum Seasons {
         if (this == LAST_LIFE) return new LastLife();
         if (this == DOUBLE_LIFE) return new DoubleLife();
         if (this == LIMITED_LIFE) return new LimitedLife();
+        if (this == LIMITED_LAST_LIFE) {
+            return getSeasonFromClassName("net.mat0u5.lifeseries.seasons.season.limitedlastlife.LimitedLastLife", new LimitedLife());
+        }
         if (this == SECRET_LIFE) return new SecretLife();
         if (this == WILD_LIFE) return new WildLife();
         if (this == PAST_LIFE) return new PastLife();
@@ -97,6 +101,12 @@ public enum Seasons {
         return allSeasons;
     }
 
+    public static List<Seasons> getVisibleSeasonsInGui() {
+        List<Seasons> allSeasons = getSeasons();
+        allSeasons.remove(LIMITED_LAST_LIFE);
+        return allSeasons;
+    }
+
     public static List<Seasons> getAprilFoolsSeasons() {
         return new ArrayList<>(List.of(REAL_LIFE, SIMPLE_LIFE));
     }
@@ -107,5 +117,21 @@ public enum Seasons {
             seasonNames.add(season.getId());
         }
         return seasonNames;
+    }
+
+    public boolean isLimitedLifeLike() {
+        return this == LIMITED_LIFE || this == LIMITED_LAST_LIFE;
+    }
+
+    private Season getSeasonFromClassName(String className, Season fallback) {
+        try {
+            Class<?> clazz = Class.forName(className);
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+            if (instance instanceof Season season) {
+                return season;
+            }
+        }
+        catch (Exception ignored) {}
+        return fallback;
     }
 }

--- a/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlife/LimitedLifeConfig.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlife/LimitedLifeConfig.java
@@ -109,6 +109,10 @@ public class LimitedLifeConfig extends ConfigManager {
             "time_randomize_interval", Time.hours(1).getSeconds(), ConfigTypes.SECONDS, "global.lives.random",
             "Time Randomize Intervals", "The intervals on which the time randomize can land."
     );
+    public static final ConfigFileEntry<String> EXTRA_LIFE_COLORS = new ConfigFileEntry<>(
+            "extra_life_colors", "", ConfigTypes.TEXT, "season.time",
+            "Extra Life Colors", "Additional color ranges for time in the format 'min-max:color'. Separate multiple entries with ';' (example: 0-3600:dark_red;115200-2147483647:blue)."
+    );
 
     public static final ConfigFileEntry<Object> GROUP_TIME = new ConfigFileEntry<>(
             "group_time", null, ConfigTypes.TEXT, "{season.time}",
@@ -116,7 +120,11 @@ public class LimitedLifeConfig extends ConfigManager {
     );
 
     public LimitedLifeConfig() {
-        super("./config/"+ Main.MOD_ID,"limitedlife.properties");
+        this("limitedlife.properties");
+    }
+
+    protected LimitedLifeConfig(String fileName) {
+        super("./config/"+ Main.MOD_ID, fileName);
     }
 
     @Override
@@ -146,11 +154,17 @@ public class LimitedLifeConfig extends ConfigManager {
                 ,TIME_DEATH_BOOGEYMAN
                 ,TIME_KILL
                 ,TIME_KILL_BOOGEYMAN
+                ,EXTRA_LIFE_COLORS
         ));
     }
 
     @Override
     public void instantiateProperties() {
+        applyLimitedLifeDefaults();
+        super.instantiateProperties();
+    }
+
+    protected void applyLimitedLifeDefaults() {
         CUSTOM_ENCHANTER_ALGORITHM.defaultValue = true;
         BLACKLIST_ITEMS.defaultValue = TextUtils.formatString("[{}]", BLACKLISTED_ITEMS);
         BLACKLIST_BLOCKS.defaultValue = TextUtils.formatString("[{}]", BLACKLISTED_BLOCKS);
@@ -183,6 +197,5 @@ public class LimitedLifeConfig extends ConfigManager {
         LIVES_RANDOMIZE_MAX.type = ConfigTypes.SECONDS;
         LIVES_LIFE_DIFF_MESSAGE.displayName = "Show Time Diff In Death Message";
         LIVES_LIFE_DIFF_MESSAGE.description = "Shows an indicator of how much time was lost in the death messages.";
-        super.instantiateProperties();
     }
 }

--- a/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlife/LimitedLifeLivesManager.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/season/limitedlife/LimitedLifeLivesManager.java
@@ -9,6 +9,7 @@ import net.mat0u5.lifeseries.utils.other.TextUtils;
 import net.mat0u5.lifeseries.utils.other.Time;
 import net.mat0u5.lifeseries.utils.player.PlayerUtils;
 import net.mat0u5.lifeseries.utils.player.ScoreboardUtils;
+import net.mat0u5.lifeseries.utils.player.TeamUtils;
 import net.mat0u5.lifeseries.utils.world.AnimationUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -17,6 +18,8 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 
 import java.util.Locale;
+import java.util.ArrayList;
+import java.util.List;
 
 import static net.mat0u5.lifeseries.Main.currentSeason;
 import static net.mat0u5.lifeseries.Main.seasonConfig;
@@ -28,9 +31,20 @@ public class LimitedLifeLivesManager extends LivesManager {
     public static int RED_TIME = 28800;
     public static boolean BROADCAST_COLOR_CHANGES = false;
     public static int TIME_RANDOMIZE_INTERVAL = Time.hours(1).getSeconds();
+    public static List<CustomLifeColorRange> EXTRA_LIFE_COLORS = new ArrayList<>();
+    private static final int EXTRA_TEAM_START_INDEX = 5;
+
+    public record CustomLifeColorRange(int min, int max, ChatFormatting color) {}
 
     @Override
     public ChatFormatting getColorForLives(Integer lives) {
+        if (lives != null) {
+            for (CustomLifeColorRange range : EXTRA_LIFE_COLORS) {
+                if (lives >= range.min() && lives <= range.max()) {
+                    return range.color();
+                }
+            }
+        }
         lives = getEquivalentLives(lives);
         if (lives == null) return ChatFormatting.GRAY;
         if (lives == 1) return ChatFormatting.RED;
@@ -49,6 +63,14 @@ public class LimitedLifeLivesManager extends LivesManager {
 
     @Override
     public String getTeamForLives(Integer lives) {
+        if (lives != null) {
+            for (int i = 0; i < EXTRA_LIFE_COLORS.size(); i++) {
+                CustomLifeColorRange range = EXTRA_LIFE_COLORS.get(i);
+                if (lives >= range.min() && lives <= range.max()) {
+                    return "lives_" + (EXTRA_TEAM_START_INDEX + i);
+                }
+            }
+        }
         lives = getEquivalentLives(lives);
         if (lives == null) return "lives_null";
         if (lives == 1) return "lives_1";
@@ -56,6 +78,51 @@ public class LimitedLifeLivesManager extends LivesManager {
         if (lives == 3) return "lives_3";
         if (lives >= 4) return "lives_4";
         return "lives_0";
+    }
+
+    @Override
+    public void createTeams() {
+        super.createTeams();
+        for (int i = 0; i < EXTRA_LIFE_COLORS.size(); i++) {
+            CustomLifeColorRange range = EXTRA_LIFE_COLORS.get(i);
+            int teamIndex = EXTRA_TEAM_START_INDEX + i;
+            TeamUtils.createTeam("lives_" + teamIndex, "Extra", range.color());
+        }
+    }
+
+    @Override
+    public int defaultTeamCanKill(String teamName) {
+        Integer equivalentLives = getEquivalentLivesFromExtraTeamName(teamName);
+        if (equivalentLives != null) {
+            if (equivalentLives <= 1) return 1;
+            if (equivalentLives == 2) return YELLOW_TIME;
+            return -1;
+        }
+        return super.defaultTeamCanKill(teamName);
+    }
+
+    @Override
+    public int defaultTeamGainLife(String teamName) {
+        Integer equivalentLives = getEquivalentLivesFromExtraTeamName(teamName);
+        if (equivalentLives != null) {
+            if (equivalentLives <= 1) return 1;
+            if (equivalentLives == 2) return YELLOW_TIME;
+            return -1;
+        }
+        return super.defaultTeamGainLife(teamName);
+    }
+
+    private Integer getEquivalentLivesFromExtraTeamName(String teamName) {
+        if (teamName == null || !teamName.startsWith("lives_")) return null;
+        try {
+            int teamIndex = Integer.parseInt(teamName.replace("lives_", ""));
+            int rangeIndex = teamIndex - EXTRA_TEAM_START_INDEX;
+            if (rangeIndex < 0 || rangeIndex >= EXTRA_LIFE_COLORS.size()) return null;
+            CustomLifeColorRange range = EXTRA_LIFE_COLORS.get(rangeIndex);
+            return getEquivalentLives(range.max());
+        }
+        catch (Exception ignored) {}
+        return null;
     }
 
     @Override
@@ -141,6 +208,38 @@ public class LimitedLifeLivesManager extends LivesManager {
     public void reload() {
         super.reload();
         TIME_RANDOMIZE_INTERVAL = LimitedLifeConfig.TIME_RANDOMIZE_INTERVAL.get();
+        EXTRA_LIFE_COLORS = parseExtraLifeColors(LimitedLifeConfig.EXTRA_LIFE_COLORS.get());
+        createTeams();
+        updateTeams();
+        currentSeason.reloadAllPlayerTeams();
+
+    }
+
+    public static List<CustomLifeColorRange> parseExtraLifeColors(String rawValue) {
+        List<CustomLifeColorRange> parsed = new ArrayList<>();
+        if (rawValue == null || rawValue.isBlank()) return parsed;
+
+        String[] entries = rawValue.split(";");
+        for (String entry : entries) {
+            String trimmedEntry = entry.trim();
+            if (trimmedEntry.isEmpty() || !trimmedEntry.contains(":")) continue;
+
+            String[] split = trimmedEntry.split(":", 2);
+            String range = split[0].trim();
+            String colorName = split[1].trim();
+            if (!range.contains("-")) continue;
+
+            String[] bounds = range.split("-", 2);
+            try {
+                int min = Integer.parseInt(bounds[0].trim());
+                int max = Integer.parseInt(bounds[1].trim());
+                ChatFormatting color = ChatFormatting.getByName(colorName);
+                if (color == null || max < min) continue;
+                parsed.add(new CustomLifeColorRange(min, max, color));
+            }
+            catch (Exception ignored) {}
+        }
+        return parsed;
 
     }
 

--- a/src/main/java/net/mat0u5/lifeseries/seasons/session/SessionTranscript.java
+++ b/src/main/java/net/mat0u5/lifeseries/seasons/session/SessionTranscript.java
@@ -111,7 +111,7 @@ public class SessionTranscript {
     }
 
     public static void assignRandomLives(ServerPlayer player, int amount) {
-        if (currentSeason.getSeason() != Seasons.LIMITED_LIFE) {
+        if (!currentSeason.getSeason().isLimitedLifeLike()) {
             addMessageWithTime(TextUtils.formatString("{} has been randomly assigned {} lives", player, amount));
         }
         else {
@@ -162,7 +162,7 @@ public class SessionTranscript {
     }
 
     public static void onPlayerLostAllLives(ServerPlayer player) {
-        if (currentSeason.getSeason() != Seasons.LIMITED_LIFE) {
+        if (!currentSeason.getSeason().isLimitedLifeLike()) {
             addMessageWithTime(TextUtils.formatString("{} lost all lives.", player));
         }
         else {
@@ -198,7 +198,7 @@ public class SessionTranscript {
             for (PlayerRecord playerRecord : playerRecords.values()) {
                 Integer startLives = playerRecord.startLives;
                 Integer endLives = playerRecord.getCurrentLives();
-                if (currentSeason.getSeason() != Seasons.LIMITED_LIFE) {
+                if (!currentSeason.getSeason().isLimitedLifeLike()) {
                     messages.add(TextUtils.formatString("\t{}: {} -> {}",playerRecord.name, startLives, endLives));
                 }
                 else {


### PR DESCRIPTION
### Motivation
- Add a standalone addon that provides a "Limited-Last Life" season implementation and make the codebase treat Limited-Last variants consistently without duplicating logic.
- Support configurable extra color/time ranges and corresponding teams so server operators can define additional time-color bands beyond the default ones.
- Preserve existing team assignments by backing up and restoring teams when switching into/out of the limited-last-life season.

### Description
- Introduces a new Fabric addon at `addons/limitedlastlife-addon` including `README.md`, Gradle build files, `fabric.mod.json`, a `LimitedLastLife` season implementation, and `LimitedLastLifeLivesManager` which implements backup/restore and custom team coloring/behavior.
- Adds `Seasons.LIMITED_LAST_LIFE`, a reflective loader for optional season classes, a `Seasons.isLimitedLifeLike()` helper, and `Seasons.getVisibleSeasonsInGui()` to hide the addon-only season from the GUI.
- Replaces numerous direct equality checks against `Seasons.LIMITED_LIFE` with the generic `isLimitedLifeLike()` so both `LIMITED_LIFE` and `LIMITED_LAST_LIFE` share behavior without code duplication (UI, HUD, commands, scoring, boogeyman/advanced-deaths, team defaults, etc.).
- Extends limited-life config and manager: adds `EXTRA_LIFE_COLORS` config entry, refactors `LimitedLifeConfig` default initialization, and enhances `LimitedLifeLivesManager` to parse `EXTRA_LIFE_COLORS`, create extra teams, map arbitrary time ranges to colors/teams, and adjust default team kill/gain rules for extra teams.

### Testing
- Built the main project successfully using `./gradlew build` and verified the modified codebase compiles without errors.
- Built the addon with `./gradlew -p addons/limitedlastlife-addon build -Plifeseries_jar=/absolute/path/to/lifeseries.jar` and the addon jar was produced successfully.
- No new automated unit tests were added as part of this change and existing automated tests were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a31642efe88327ace298c2206b5e12)